### PR TITLE
Revert PARQUET-1414 because it causes empty pages to be written in Spark

### DIFF
--- a/FORK.md
+++ b/FORK.md
@@ -2,7 +2,7 @@
 This repo exists mostly to make releases of parquet-mr more often. The only difference to upstream is as follows:
 
 1. Solution for [PARQUET-686](https://issues.apache.org/jira/browse/PARQUET-686).
-2. Temporarily revert PARQUET-1414 because it causes Spark to write unreadable empty Parquet pages.
+2. Temporarily revert [PARQUET-1414](https://issues.apache.org/jira/browse/PARQUET-1414) because it causes Spark to write unreadable empty Parquet pages.
 
 The change that we had made that upstream only made in statistics v2 is to change binary comparison to be unsigned and declare all statistics priori to that change as corrupted. This lets us more quickly take advantage of binary statistics and removes burden on user to know whether they should account for signed binary comparison in their values.
 

--- a/FORK.md
+++ b/FORK.md
@@ -1,5 +1,8 @@
 # Differences to mainline
-This repo exists mostly to make releases of parquet-mr more often. The only difference to upstream is solution for [PARQUET-686](https://issues.apache.org/jira/browse/PARQUET-686).
+This repo exists mostly to make releases of parquet-mr more often. The only difference to upstream is as follows:
+
+1. Solution for [PARQUET-686](https://issues.apache.org/jira/browse/PARQUET-686).
+2. Temporarily revert PARQUET-1414 because it causes Spark to write unreadable empty Parquet pages.
 
 The change that we had made that upstream only made in statistics v2 is to change binary comparison to be unsigned and declare all statistics priori to that change as corrupted. This lets us more quickly take advantage of binary statistics and removes burden on user to know whether they should account for signed binary comparison in their values.
 

--- a/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnWriteStoreBase.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnWriteStoreBase.java
@@ -67,7 +67,7 @@ abstract class ColumnWriteStoreBase implements ColumnWriteStore {
 
     this.columns = new TreeMap<>();
 
-    this.rowCountForNextSizeCheck = min(props.getMinRowCountForPageSizeCheck(), props.getPageRowCountLimit());
+    this.rowCountForNextSizeCheck = props.getMinRowCountForPageSizeCheck();
 
     columnWriterProvider = new ColumnWriterProvider() {
       @Override
@@ -95,7 +95,7 @@ abstract class ColumnWriteStoreBase implements ColumnWriteStore {
     }
     this.columns = unmodifiableMap(mcolumns);
 
-    this.rowCountForNextSizeCheck = min(props.getMinRowCountForPageSizeCheck(), props.getPageRowCountLimit());
+    this.rowCountForNextSizeCheck = props.getMinRowCountForPageSizeCheck();
 
     columnWriterProvider = new ColumnWriterProvider() {
       @Override
@@ -190,17 +190,13 @@ abstract class ColumnWriteStoreBase implements ColumnWriteStore {
 
   private void sizeCheck() {
     long minRecordToWait = Long.MAX_VALUE;
-    int pageRowCountLimit = props.getPageRowCountLimit();
-    long rowCountForNextRowCountCheck = rowCount + pageRowCountLimit;
     for (ColumnWriterBase writer : columns.values()) {
       long usedMem = writer.getCurrentPageBufferedSize();
       long rows = rowCount - writer.getRowsWrittenSoFar();
       long remainingMem = props.getPageSizeThreshold() - usedMem;
-      if (remainingMem <= thresholdTolerance || rows >= pageRowCountLimit) {
+      if (remainingMem <= thresholdTolerance) {
         writer.writePage();
         remainingMem = props.getPageSizeThreshold();
-      } else {
-        rowCountForNextRowCountCheck = min(rowCountForNextRowCountCheck, rowCount + (pageRowCountLimit - rows));
       }
       long rowsToFillPage =
           usedMem == 0 ?
@@ -222,11 +218,6 @@ abstract class ColumnWriteStoreBase implements ColumnWriteStore {
               props.getMaxRowCountForPageSizeCheck());
     } else {
       rowCountForNextSizeCheck = rowCount + props.getMinRowCountForPageSizeCheck();
-    }
-
-    // Do the check earlier if required to keep the row count limit
-    if (rowCountForNextRowCountCheck < rowCountForNextSizeCheck) {
-      rowCountForNextSizeCheck = rowCountForNextRowCountCheck;
     }
   }
 }

--- a/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnWriteStoreBase.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnWriteStoreBase.java
@@ -200,7 +200,7 @@ abstract class ColumnWriteStoreBase implements ColumnWriteStore {
         writer.writePage();
         remainingMem = props.getPageSizeThreshold();
       } else {
-        rowCountForNextRowCountCheck = min(rowCountForNextRowCountCheck, writer.getRowsWrittenSoFar() + pageRowCountLimit);
+        rowCountForNextRowCountCheck = min(rowCountForNextRowCountCheck, rowCount + (pageRowCountLimit - rows));
       }
       long rowsToFillPage =
           usedMem == 0 ?

--- a/parquet-column/src/test/java/org/apache/parquet/column/mem/TestMemColumn.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/mem/TestMemColumn.java
@@ -18,28 +18,19 @@
  */
 package org.apache.parquet.column.mem;
 
-import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
-import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.ColumnReader;
-import org.apache.parquet.column.ColumnWriteStore;
 import org.apache.parquet.column.ColumnWriter;
 import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.column.impl.ColumnReadStoreImpl;
 import org.apache.parquet.column.impl.ColumnWriteStoreV1;
-import org.apache.parquet.column.impl.ColumnWriteStoreV2;
-import org.apache.parquet.column.page.DataPage;
-import org.apache.parquet.column.page.PageReader;
 import org.apache.parquet.column.page.mem.MemPageStore;
 import org.apache.parquet.example.DummyRecordConverter;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.MessageTypeParser;
-import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
-import org.apache.parquet.schema.Types;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -172,68 +163,6 @@ public class TestMemColumn {
       }
       columnReader.consume();
       ++ i;
-    }
-  }
-
-  @Test
-  public void testPageSize() {
-    MessageType schema = Types.buildMessage()
-        .requiredList().requiredElement(BINARY).named("binary_col")
-        .requiredList().requiredElement(INT32).named("int32_col")
-        .named("msg");
-    System.out.println(schema);
-    MemPageStore memPageStore = new MemPageStore(123);
-
-    // Using V2 pages so we have rowCount info
-    ColumnWriteStore writeStore = new ColumnWriteStoreV2(schema, memPageStore, ParquetProperties.builder()
-        .withPageSize(1024) // Less than 10 records for binary_col
-        .withMinRowCountForPageSizeCheck(1) // Enforce having precise page sizing
-        .withPageRowCountLimit(10)
-        .withDictionaryEncoding(false) // Enforce having large binary_col pages
-        .build());
-    ColumnDescriptor binaryCol = schema.getColumnDescription(new String[] { "binary_col", "list", "element" });
-    ColumnWriter binaryColWriter = writeStore.getColumnWriter(binaryCol);
-    ColumnDescriptor int32Col = schema.getColumnDescription(new String[] { "int32_col", "list", "element" });
-    ColumnWriter int32ColWriter = writeStore.getColumnWriter(int32Col);
-    // Writing 123 records
-    for (int i = 0; i < 123; ++i) {
-      // Writing 10 values per record
-      for (int j = 0; j < 10; ++j) {
-        binaryColWriter.write(Binary.fromString("aaaaaaaaaaaa"), j == 0 ? 0 : 2, 2);
-        int32ColWriter.write(42, j == 0 ? 0 : 2, 2);
-      }
-      writeStore.endRecord();
-    }
-    writeStore.flush();
-
-    // Check that all the binary_col pages are <= 1024 bytes
-    {
-      PageReader binaryColPageReader = memPageStore.getPageReader(binaryCol);
-      assertEquals(1230, binaryColPageReader.getTotalValueCount());
-      int pageCnt = 0;
-      int valueCnt = 0;
-      while (valueCnt < binaryColPageReader.getTotalValueCount()) {
-        DataPage page = binaryColPageReader.readPage();
-        ++pageCnt;
-        valueCnt += page.getValueCount();
-        LOG.info("binary_col page-{}: {} bytes, {} rows", pageCnt, page.getCompressedSize(), page.getIndexRowCount().get());
-        assertTrue("Compressed size should be less than 1024", page.getCompressedSize() <= 1024);
-      }
-    }
-
-    // Check that all the int32_col pages contain <= 10 rows
-    {
-      PageReader int32ColPageReader = memPageStore.getPageReader(int32Col);
-      assertEquals(1230, int32ColPageReader.getTotalValueCount());
-      int pageCnt = 0;
-      int valueCnt = 0;
-      while (valueCnt < int32ColPageReader.getTotalValueCount()) {
-        DataPage page = int32ColPageReader.readPage();
-        ++pageCnt;
-        valueCnt += page.getValueCount();
-        LOG.info("int32_col page-{}: {} bytes, {} rows", pageCnt, page.getCompressedSize(), page.getIndexRowCount().get());
-        assertTrue("Row count should be less than 10", page.getIndexRowCount().get() <= 10);
-      }
     }
   }
 

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputFormat.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputFormat.java
@@ -144,7 +144,6 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
   public static final String MAX_ROW_COUNT_FOR_PAGE_SIZE_CHECK = "parquet.page.size.row.check.max";
   public static final String ESTIMATE_PAGE_SIZE_CHECK = "parquet.page.size.check.estimate";
   public static final String COLUMN_INDEX_TRUNCATE_LENGTH = "parquet.columnindex.truncate.length";
-  public static final String PAGE_ROW_COUNT_LIMIT = "parquet.page.row.count.limit";
 
   public static JobSummaryLevel getJobSummaryLevel(Configuration conf) {
     String level = conf.get(JOB_SUMMARY_LEVEL);
@@ -326,18 +325,6 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
     return conf.getInt(COLUMN_INDEX_TRUNCATE_LENGTH, ParquetProperties.DEFAULT_COLUMN_INDEX_TRUNCATE_LENGTH);
   }
 
-  public static void setPageRowCountLimit(JobContext jobContext, int rowCount) {
-    setPageRowCountLimit(getConfiguration(jobContext), rowCount);
-  }
-
-  public static void setPageRowCountLimit(Configuration conf, int rowCount) {
-    conf.setInt(PAGE_ROW_COUNT_LIMIT, rowCount);
-  }
-
-  private static int getPageRowCountLimit(Configuration conf) {
-    return conf.getInt(PAGE_ROW_COUNT_LIMIT, ParquetProperties.DEFAULT_PAGE_ROW_COUNT_LIMIT);
-  }
-
   private WriteSupport<T> writeSupport;
   private ParquetOutputCommitter committer;
 
@@ -393,7 +380,6 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
         .withMinRowCountForPageSizeCheck(getMinRowCountForPageSizeCheck(conf))
         .withMaxRowCountForPageSizeCheck(getMaxRowCountForPageSizeCheck(conf))
         .withColumnIndexTruncateLength(getColumnIndexTruncateLength(conf))
-        .withPageRowCountLimit(getPageRowCountLimit(conf))
         .build();
 
     long blockSize = getLongBlockSize(conf);
@@ -412,7 +398,6 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
       LOG.info("Min row count for page size check is: {}", props.getMinRowCountForPageSizeCheck());
       LOG.info("Max row count for page size check is: {}", props.getMaxRowCountForPageSizeCheck());
       LOG.info("Truncate length for column indexes is: {}", props.getColumnIndexTruncateLength());
-      LOG.info("Page row count limit to {}", props.getPageRowCountLimit());
     }
 
     WriteContext init = writeSupport.init(conf);

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
@@ -426,17 +426,6 @@ public class ParquetWriter<T> implements Closeable {
     }
 
     /**
-     * Sets the Parquet format page row count limit used by the constructed writer.
-     *
-     * @param rowCount limit for the number of rows stored in a page
-     * @return this builder for method chaining
-     */
-    public SELF withPageRowCountLimit(int rowCount) {
-      encodingPropsBuilder.withPageRowCountLimit(rowCount);
-      return self();
-    }
-
-    /**
      * Set the Parquet format dictionary page size used by the constructed
      * writer.
      *


### PR DESCRIPTION
PARQUET-1414 isn't compatible with the Spark Parquet Data Source, as Spark can inadvertently cause empty pages to be written.

The problem is that in Spark's ParquetWriteSupport, Spark may choose not to write records, particularly if they are empty in optional columns, but will still indicate to the Parquet file writer that records are processed. When Spark indicates to Parquet that records are processed, Parquet might attempt to flush the page to the column chunk, since the number of records counting towards the page row limit introduced in PARQUET-1414 only accounts for the number of signals of processed rows, and not the number of values in the page directly. Suppose the Parquet page row limit is N. Then if Spark receives N null cells for a column, the Parquet writer will think there are N records filling the page (when in fact there are zero), and then write the empty page.

This is most likely to occur in Parquet writes where a column is sparsely populated.

We revert here for now, targeting to patch Spark in the near future, and then re-applying PARQUET-1414 following.